### PR TITLE
Update the recommended matebook-applet version

### DIFF
--- a/debian/huawei-wmi-1.1.0/debian/control
+++ b/debian/huawei-wmi-1.1.0/debian/control
@@ -10,6 +10,6 @@ Section: misc
 Priority: optional
 Architecture: all
 Depends: ${misc:Depends}
-Recommends: matebook-applet (>= 1.3)
+Recommends: matebook-applet (>= 2.1.4)
 Description: Huawei WMI Privilege & Reinstate
  Sets group write privileges and reinstates battery charge-thresholds.


### PR DESCRIPTION
Version 2.1.4 is the first one to support different files in /etc/default/huawei-wmi/ - previous versions are likely to mess things up if driver version is > 3.2